### PR TITLE
Use "Laravel\Nova\Resource" instead of "App\Nova\Resource"

### DIFF
--- a/src/InlineMorphTo.php
+++ b/src/InlineMorphTo.php
@@ -2,7 +2,7 @@
 
 namespace DigitalCreative\InlineMorphTo;
 
-use App\Nova\Resource;
+use Laravel\Nova\Resource;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Fields\BelongsToMany;


### PR DESCRIPTION
If I try to use a field in a package, it throws this error:  `Argument 1 passed to DigitalCreative\InlineMorphTo\InlineMorphTo::resolveFields() must be an instance of App\Nova\Resource, instance of...`