### PR TITLE
Allow to edit InlineMorphTo Field after creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "digital-creative/nova-inline-morph-to",
+    "name": "marispro/nova-inline-morph-to",
     "description": "A Laravel Nova field for displaying morphTo relationship inline.",
     "keywords": [
         "laravel",

--- a/src/InlineMorphTo.php
+++ b/src/InlineMorphTo.php
@@ -222,7 +222,7 @@ class InlineMorphTo extends Field
         $resourceClass = $request->input($this->attribute);
 
         if ($this->typeUpdateable) {
-            if ($model->{$this->attribute} !== null && get_class($model->{$this->attribute}) == $resourceClass::newModel()) {
+            if ($model->{$this->attribute} !== null && get_class($model->{$this->attribute}) == get_class($resourceClass::newModel())) {
                 // same related model
                 $relatedInstance = $model->{$this->attribute};
             } else {


### PR DESCRIPTION
Allow the developer to control if the polymorphic relationship can be changed after creation. Default behaviour is current behaviour - readonly

Fix for https://github.com/dcasia/nova-inline-morph-to/issues/24